### PR TITLE
🐛 fix: update link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ hero:
   description: 一款功能强大、易用灵活的流程编辑器框架，帮助你轻松构建复杂的工作流和流程产品。
   actions:
     - text: 快速上手
-      link: /guide
+      link: /use-docs/quick-doc
     - text: Github
       link: https://github.com/ant-design/pro-flow
 ---


### PR DESCRIPTION
<img width="1920" alt="image" src="https://github.com/ant-design/pro-flow/assets/31075337/0f29be3d-e0b3-4e8a-bdc4-214a213e200a">

/guide is not found.   
Maybe it should be replaced with /use-docs/quick-doc.