### PR TITLE
🐛fix bug: BoxSelect has been replaced by  BoxSelectIcon （#115）

### DIFF
--- a/src/FlowEditor/features/ContextMenu/useMenuAction.tsx
+++ b/src/FlowEditor/features/ContextMenu/useMenuAction.tsx
@@ -1,5 +1,5 @@
 import { ZoomInOutlined, ZoomOutOutlined } from '@ant-design/icons';
-import { BoxSelect, ClipboardList } from 'lucide-react';
+import { BoxSelectIcon, ClipboardList } from 'lucide-react';
 import { useMemo } from 'react';
 import { useReactFlow } from 'reactflow';
 
@@ -26,7 +26,7 @@ export const useMenuActions = () => {
       selectAll: {
         key: 'selectAll',
         label: '选择全部',
-        icon: <BoxSelect size={size} />,
+        icon: <BoxSelectIcon size={size} />,
         onClick: selectAll,
         shortcut: ['meta', 'A'],
       },


### PR DESCRIPTION
fix bug: BoxSelect has been replaced by  BoxSelectIcon （#115）
ref: https://github.com/lucide-icons/lucide/issues/2733